### PR TITLE
Use stable version of CppUtest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ compiler:
 
 before_install:
     - sudo pip install pyaml jinja2
-    - git clone https://github.com/cpputest/cpputest ../cpputest
-    - pushd ../cpputest
-    - autoreconf
+    - pushd ..
+    - wget "https://github.com/cpputest/cpputest.github.io/blob/master/releases/cpputest-3.6.tar.gz?raw=true" -O cpputest.tar.gz
+    - tar -xzf cpputest.tar.gz 
+    - cd cpputest-3.6/
     - ./configure
     - make
     - sudo make install


### PR DESCRIPTION
As pointed out by @pierluca, it is better if the Travis build uses the same version as the dev VM, especially now that CppUtest is changing its build system.

When / If this get merged, I will push those changes to other CVRA repositories too.
